### PR TITLE
Add detailed branch naming rules

### DIFF
--- a/branch/README.md
+++ b/branch/README.md
@@ -1,6 +1,7 @@
 # Git branching guidance
 ## We should keep these rules.
 - 모든 새 기능은 `feature` 브랜치를 이용합니다.
+- 기존 기능의 개선은 `enhancement` 브랜치를 이용합니다.
 - 기능 수정과 버그 수정은 `fix` 브랜치를 이용합니다.
 - `develop` 브랜치에 행해지는 모든 `merge`는 `pull request` 기능을 통하여 `review` 받습니다.
   - 해당 프로젝트의 모든 팀원의 `approve`를 얻은 후 최종적으로 `merge`합니다.
@@ -11,29 +12,71 @@
 
 ## Branches
 - 우리가 사용하는 브랜치들은 다음과 같습니다.
-  - `master`, `develop`, `feature`, `fix`, `hotfix`
+  - `master`, `develop`, `feature`, `enhancement`, `fix`, `hotfix`
 
 ### `develop` branch
 - `develop` 브랜치는 개발에 있어 메인 파트를 담당합니다.
 - 최초의 `develop` 브랜치는 `master`에서 갈라져 나옵니다.
 
-### `feature` branch
-- `feature` 브랜치는 모든 기능 개발을 담당합니다.
-- `feature` 브랜치는 항상 `develop`에서 생성되며, 작업이 완료되면 `develop`에 `merge`됩니다.
-- `feature` 브랜치의 이름은 다음과 같이 명명합니다.
-  - 해당하는 issue를 작성하였을 경우
-    - feature/issue#37
-  - 해당하는 issue가 없을 경우
-    - feature/setup-project
-- Significant update의 경우 중계 브렌치를 거쳐 `develop`에 머지됩니다. 이 경우 중계 브랜치 및 `feature` 브랜치의 이름은 다음과 같이 정합니다.
-  - 중계 브렌치: feature/feature-name/base
-  - 기능 브렌치: feature/feature-name/specific-feature
-  ![예시](../images/branch_1.png)
-  - 이 경우에도, 기능 브랜치는 `pull request` 기능을 이용해 `review`를 받은 후 중계 브랜치에 `merge`합니다.
+### Sub branches
+- *sub* 브랜치들은 다음과 같습니다
+  - `feature`
+  - `enhancement`
+  - `fix`
+- *sub* 브랜치들은 항상 `develop`에서 생성되며, 작업이 완료되면 `develop`에 `merge`됩니다.
+- 기본 네이밍 규칙
+  - 해당하는 issue를 작성하였을 경우 이슈 번호를 기재합니다.
+    - *sub-branch*/issue#37
+  - 해당하는 issue가 없을 경우 아래와 같이 명명합니다.
+    - *sub-branch*/[동사-]명사
+- 세부 네이밍 규칙
+  - 유저명은 적지 않습니다.
+  - 기본적으로 명사만 적되 필요한 경우 동사를 붙입니다.
+    <pre>
+    // Bad
+    feature/create-guestVoterAuth<br/>
+    // Good
+    feature/guest-voter-auth
+    </pre>
+    <pre>
+    // Bad
+    feature/create-develop-router<br/>
+    // Good
+    feature/dev-router
+    </pre>
+    <pre>
+    // Good
+    enhancement/readme
+    enhancement/<b>upgrade</b>-node-ubuntu
+    enhancement/<b>hide</b>-docker-directory
+    fix/build-script
+    </pre>
+  - 너무 모호하게/자세하게 적지 않습니다.
+    <pre>
+    // Too specific
+    feature/push_for_staff_with_admin_page
+    feature/manage_admin_page_by_permission
+    fix/login_using_master_hr_table<br/>
+    // Too generic
+    hotfix/oracle
+    feature/election-related
+    </pre>
 
-### `fix` branch
-- `fix` 브랜치는 기능 수정, 버그 수정 등 이미 개발된 부분의 수정을 담당합니다
-- `fix` 브랜치의 세부 규칙은 `feature` 브랜치와 같습니다.
+- Significant update의 경우 중계 브렌치를 거쳐 `develop`에 머지됩니다. 이 경우 중계 브랜치 및 *sub* 브랜치의 이름은 다음과 같이 정합니다.
+  - `feature` 브랜치의 예:
+    - 중계 브렌치: feature/feature-name/base
+    - 기능 브렌치: feature/feature-name/specific-feature
+    ![예시](../images/branch_1.png)
+    - 이 경우에도, 기능 브랜치는 `pull request` 기능을 이용해 `review`를 받은 후 중계 브랜치에 `merge`합니다.
+
+#### `feature` branch
+- `feature` 브랜치는 모든 기능 개발을 담당합니다.
+
+#### `enhancement` branch
+- `enhancement` 브랜치는 이미 개발된 부분의 기능 개선, README/템플릿 등의 비기능적인 개선 등을 담당합니다.
+
+#### `fix` branch
+- `fix` 브랜치는 기능 수정, 버그 수정 등 이미 개발된 부분의 수정을 담당합니다.
 
 ### `master` branch
 - 이 브랜치는 항상 출시가 가능한 상태로 유지됩니다.


### PR DESCRIPTION
Resolves #8

## Proposed Changes
- Add detailed branch naming rules and examples
- Add enhancement branch
  - This is because currently `Fix` branch contains not only "fix to certain problems" but also things like README and some other small enhancements which aren't necessarily a "fix".
  - This will make branch names shorter and more concise.

## Notes
- Please let me know if you have any other idea.