### PR TITLE
Bug: PR 종료 시, issue가 자동으로 닫히지 않는 현상

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-해결된 이슈: #ISSUE_ID
+Resolves #ISSUE_ID
 
 ## 작업 배경
 - 작업 배경을 기록하세요.


### PR DESCRIPTION
해결된 이슈: #23 

## 작업 배경
- 이슈 템플릿을 변경한 후, PR 종료 시, issue가 자동으로 닫히지 않는 현상이 나타남

## 작업 내용
- github에 issue를 자동으로 종료 해주는 keyword가 지정되있습니다.
  - close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved [참고 문서](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests)
  - 저희는 기존 resolves/fix 에서 "해결된 이슈" 라는 한국어로 변경 해서 자동으로 issue가 안닫히고 있는것 같습니다.
 
## 기타
- 참고 문서 내용 중
  - 커밋 메세지를 `resolve #20` 이런식으로 작성하면 커밋으로 issue를 닫는것도 된다고 하네요.
