### PR TITLE
Feature: Commit convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Purpose
 This repository contains various rules/conventions over general Git/GitHub usage.
 
-You can find detailed information under the respective sections:
+You can find detailed information under respective sections:
+- [Commit Convention](./commit)
 - [Branch Convention](./branch)
 - [Pull Request Convention](./pr)

--- a/commit/README.md
+++ b/commit/README.md
@@ -8,7 +8,11 @@
 
 # Setup
 ```console
-npm install --save-dev @commitlint/cli @commitlint/config-conventional
+$ cd new_project
+
+new_project $ npm install --save-dev @commitlint/cli @commitlint/config-conventional
+# Setup commitlint hooks
+new_project $ sh <(curl -s https://raw.githubusercontent.com/QuesDevTeam/Git-Convention/master/commit/init.sh)
 ```
 
 # Rules

--- a/commit/README.md
+++ b/commit/README.md
@@ -1,3 +1,11 @@
+# Terminologies
+- header: 첫 라인. 일반적으로 생각하는 커밋 메시지
+  - type: `feat, fix` 등 커밋의 타입
+  - scope: 모노레포에서 사용. `(@project)`와 같이 해당 커밋의 스코프를 명시.
+  - subject: 위 `type`을 제외한 실제 커밋 메시지
+- body: 중간 라인. 부가 설명이 필요한 경우 작성.
+- footer: 마지막 라인. **현재 미사용**
+
 # Setup
 ```console
 npm install --save-dev @commitlint/cli @commitlint/config-conventional

--- a/commit/README.md
+++ b/commit/README.md
@@ -12,6 +12,7 @@ $ cd new_project
 
 new_project $ npm install --save-dev @commitlint/cli @commitlint/config-conventional
 # Setup commitlint hooks
+new_project $ curl -LO https://raw.githubusercontent.com/QuesDevTeam/Git-Convention/master/commit/commitlint.config.js
 new_project $ sh <(curl -s https://raw.githubusercontent.com/QuesDevTeam/Git-Convention/master/commit/init.sh)
 ```
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -10,3 +10,27 @@
 ```console
 npm install --save-dev @commitlint/cli @commitlint/config-conventional
 ```
+
+# Rules
+[@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)를 base configuration으로 사용합니다
+
+## Custom Rules
+### header-max-length
+type을 포함한 헤더 라인의 최대 길이
+
+- Base: 100
+- Override
+  - Monorepo: 40(scope 포함)
+  - Multi-repo: 30
+  - Rationale: 평균 커밋 길이 계산 [스크립트](https://gist.github.com/crowjdh/dc072fc362c063ea6ede0d3dcb3808c8)를 사용해 QuesDevTeam의 평균 커밋 길이를 계산, 이를 커버하는 범위로 산정
+
+## Highlights
+### subject-full-stop
+한 문장으로 끝나는 경우, 예를 들면 커밋 메시지 혹은 하이픈(-)으로 시작하는 개괄식 문서 등에서는 마침표를 찍지 않습니다
+
+# References
+- [Conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
+- [commitlint rules](https://commitlint.js.org/#/reference-rules)
+  - [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
+- [Type explanations #1](https://platform.uno/docs/articles/uno-development/git-conventional-commits.html)
+- [Type explanations #2](https://lean-lang.org/lean4/doc/dev/commit_convention.html)

--- a/commit/README.md
+++ b/commit/README.md
@@ -1,0 +1,4 @@
+# Setup
+```console
+npm install --save-dev @commitlint/cli @commitlint/config-conventional
+```

--- a/commit/commitlint.config.js
+++ b/commit/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/commit/commitlint.config.js
+++ b/commit/commitlint.config.js
@@ -1,3 +1,9 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'footer-empty': [2, 'always'],
+    'footer-leading-blank': [0, 'never'],
+    'footer-max-line-length': [0, 'never'],
+    'header-max-length': [2, 'always', 50],
+  },
 };

--- a/commit/init.sh
+++ b/commit/init.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# This essentially does the same thing as what [Husky](https://typicode.github.io/husky) does
+# This essentially does the same thing as what Husky(https://typicode.github.io/husky) does
 
 COMMIT_LINT_HOOK_PATH="$PWD/.custom_git_hooks"
 COMMIT_LINT_CMT_MSG_HOOK_PATH="$COMMIT_LINT_HOOK_PATH/commit-msg"

--- a/commit/init.sh
+++ b/commit/init.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# This essentially does the same thing as what [Husky](https://typicode.github.io/husky) does
+
+COMMIT_LINT_HOOK_PATH="$PWD/.custom_git_hooks"
+COMMIT_LINT_CMT_MSG_HOOK_PATH="$COMMIT_LINT_HOOK_PATH/commit-msg"
+
+ensure_hook_dir() {
+  if [ ! -d "$COMMIT_LINT_HOOK_PATH" ]; then
+    mkdir "$COMMIT_LINT_HOOK_PATH"
+  fi
+}
+
+create_commit_msg_hook() {
+  echo "npx --no -- commitlint --edit \"\$1\"" > "$COMMIT_LINT_CMT_MSG_HOOK_PATH"
+  chmod u+x "$COMMIT_LINT_CMT_MSG_HOOK_PATH"
+}
+
+setup_local_git_hooks_path() {
+  git config --local core.hooksPath "$COMMIT_LINT_HOOK_PATH"
+}
+
+set -e
+
+ensure_hook_dir
+create_commit_msg_hook
+setup_local_git_hooks_path


### PR DESCRIPTION
## 작업 배경
[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)를 기초로 저희 상황에 맞는 커밋 컨벤션 정리 필요성이 있다고 생각해 제안합니다. 컨벤션 자체에 대해서는 아래에서 확인할 수 있습니다:
- [개괄적인 설명](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [자세한 스펙/구현](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)

## 작업 내용
- [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) 도입
- Oneliner 스크립트를 사용해 git의 `commit-msg` 훅 셋업

## 기타
- 프런트 팀에서 이미 [Husky](https://typicode.github.io/husky)라는 라이브러리를 사용해 git hook을 셋업하고 계신 걸로 아는데, 제가 이래저래 분석해 본 결과로는 굳이 라이브러리를 추가하지 않고 간단히 처리될 수 있는 일인 것 같아서 이렇게 제안했어요. 혹시 제가 놓치고 있는 기능이나 부분이 있으면 알려주세요 :)
- 베이스 룰/커스텀 룰에 대해 의견 있으시면 알려주세요