### PR TITLE
fix: add npx binary check routine for commitlint

### DIFF
--- a/commit/init.sh
+++ b/commit/init.sh
@@ -4,6 +4,8 @@
 COMMIT_LINT_HOOK_PATH="$PWD/.custom_git_hooks"
 COMMIT_LINT_CMT_MSG_HOOK_PATH="$COMMIT_LINT_HOOK_PATH/commit-msg"
 
+ERROR_MISSING_NPX=1
+
 ensure_hook_dir() {
   if [ ! -d "$COMMIT_LINT_HOOK_PATH" ]; then
     mkdir "$COMMIT_LINT_HOOK_PATH"
@@ -11,7 +13,22 @@ ensure_hook_dir() {
 }
 
 create_commit_msg_hook() {
-  echo "npx --no -- commitlint --edit \"\$1\"" > "$COMMIT_LINT_CMT_MSG_HOOK_PATH"
+  # These lines can't be indented properly due to the
+  # property of shell script
+  cat > "$COMMIT_LINT_CMT_MSG_HOOK_PATH" << EOF
+if ! which npx &> /dev/null; then
+  echo -n "It doesn't seem like you have \"npx\", which is required"
+  echo " to run \"commitlint\"."
+
+  echo "You might want to do something like:"
+  echo "  - Installing node/npx"
+  echo "  - Run \"nvm use NODE_VERSION_OF_YOUR_CHOICE\""
+  exit $ERROR_MISSING_NPX
+fi
+
+npx --no -- commitlint --edit "\$1"
+EOF
+
   chmod u+x "$COMMIT_LINT_CMT_MSG_HOOK_PATH"
 }
 


### PR DESCRIPTION
## 작업 배경
- [commitlint setup](https://github.com/QuesDevTeam/Git-Convention/tree/master/commit#setup)시 nvm이 activate되어 있지 않은 경우 모호한 에러가 발생합니다

## 작업 내용
- 문제를 이해하기 쉽게 설명하는 에러 메시지를 추가했습니다